### PR TITLE
add aws secrets manager

### DIFF
--- a/define-policies.tf
+++ b/define-policies.tf
@@ -84,6 +84,21 @@ resource "aws_iam_role_policy_attachment" "attach-allow-elb" {
 #   name = "ecsTaskExecutionRole"
 # }
 
+data "aws_iam_policy_document" "ecs-service-allow-secrets-manager" {
+  count = "${var.aws_secrets_manager_secret_arn != "" ? 1 : 0}"
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [
+      "${var.aws_secrets_manager_secret_arn}"
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "ecs-task-access-ecr" {
   statement {
     effect = "Allow"
@@ -114,6 +129,13 @@ data "aws_iam_policy_document" "ecs-task-access-cloudwatch" {
       "*",
     ]
   }
+}
+
+resource "aws_iam_policy" "ecs-service-allow-secrets-manager" {
+  count = "${var.aws_secrets_manager_secret_arn != "" ? 1 : 0}"
+  name        = "ecs-service-allow-secrets-manager-${var.project}-${var.service}-${var.environment}"
+  description = "ECS Service policy to access Secrets Manager"
+  policy      = "${data.aws_iam_policy_document.ecs-service-allow-secrets-manager.json}"
 }
 
 resource "aws_iam_policy" "ecs-task-access-ecr" {
@@ -148,6 +170,12 @@ resource "aws_iam_role" "ecs-task-execution" {
 EOF
 
   tags = "${merge(local.default_tags, var.tags)}"
+}
+
+resource "aws_iam_role_policy_attachment" "attach-allow-secrets-manager" {
+  count = "${var.aws_secrets_manager_secret_arn != "" ? 1 : 0}"
+  role       = "${aws_iam_role.ecs-task-execution.name}"
+  policy_arn = "${aws_iam_policy.ecs-service-allow-secrets-manager.arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "attach-allow-ecr" {

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,11 @@ variable "task_role_arn" {
   default     = ""
 }
 
+variable "aws_secrets_manager_secret_arn" {
+  description = "ARN of specific AWS Secrets Manager secret which stores credentials for accessing private docker images registry"
+  default     = ""
+}
+
 variable "tags" {
   type        = "map"
   description = "Additional tags for all resources"


### PR DESCRIPTION
Within this module you cannot use private docker registry which require authentication (credentials are stored in AWS Secrets Manager).
PR adds ability to specify ARN of secret from AWS Secrets Manager wich will be used for authentication to pritave docker regisrtry (prefix in "docker_image" variable).