### PR TITLE
Update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "container_memory" {
 }
 
 variable "container_name" {
-  description = "Defines container name which will be used as target in ALB target group. If not set ${var.project}-${var.service} value will be used."
+  description = "Defines container name which will be used as target in ALB target group. If not set 'var.project-var.service' value will be used."
   default     = ""
 }
 


### PR DESCRIPTION
on .terraform/modules/ecs-fargate/variables.tf line 49, in variable "container_name":
  49:   description = "Defines container name which will be used as target in ALB target group. If not set ${var.project}-${var.service} value will be used."

Variables may not be used here.